### PR TITLE
DEV: Compile Boost and libpqxx with cmake. Update libpqxx code for libpqxx >= libpqxx

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.25)
 
 #cmake will warn about CMP0167 not being set in cmake >= 3.30.
 #Setting this as new keeps the cmake up to the latest policy standard.
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
+set(BOOST_LIBS Boost::filesystem Boost::iostreams Boost::program_options)
 
 project(restgresql LANGUAGES CXX C)
 
@@ -19,14 +20,17 @@ include(CMakePrintHelpers)
 
 find_package(Threads)
 find_package(PkgConfig)
-find_package(Boost 1.83 REQUIRED COMPONENTS filesystem iostreams program_options)
 find_package(OpenSSL)
-
-include_directories(${Boost_INCLUDE_DIRS})
 
 FetchContent_Declare(
     json
     URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+
+FetchContent_Declare(
+    libpqxx
+    URL https://github.com/jtv/libpqxx/archive/refs/tags/7.10.1.tar.gz
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
@@ -36,9 +40,13 @@ FetchContent_Declare(
     GIT_TAG 0a86bc0af22173b8c952c11551a067fd6f843d83 #7.17
 )
 
-FetchContent_MakeAvailable(json mongoose_git)
+FetchContent_Declare(
+    Boost
+    URL https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.xz
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
 
-pkg_check_modules(PQXX REQUIRED libpqxx)
+FetchContent_MakeAvailable(boost json libpqxx mongoose_git)
 
 file(COPY ${mongoose_git_SOURCE_DIR}/mongoose.h DESTINATION ${CMAKE_SOURCE_DIR}/mongoose)
 file(COPY ${mongoose_git_SOURCE_DIR}/mongoose.c DESTINATION ${CMAKE_SOURCE_DIR}/mongoose)
@@ -55,7 +63,7 @@ add_executable(
     restapi.cpp
 )
 
-target_link_libraries(restgresql PRIVATE nlohmann_json::nlohmann_json mongoose ${PQXX_LINK_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(restgresql PRIVATE nlohmann_json::nlohmann_json mongoose pqxx "${BOOST_LIBS}")
 
 install(
     TARGETS restgresql

--- a/src/postgresql.cpp
+++ b/src/postgresql.cpp
@@ -121,13 +121,12 @@ nlohmann::json PostgreSQL::pqxxResultSetToJson(const pqxx::result &rs){
     return obj;
 }
 
-//QryParams are optional for the function.
-template<typename... QryParams>
-json PostgreSQL::execGenericJsonQry(std::string qry, QryParams... qprms){
+//qprms are optional for the function.
+json PostgreSQL::execGenericJsonQry(std::string qry, pqxx::params qprms = {}){
     json data;
     try{
         pqxx::work txn{*c};
-        pqxx::result r = txn.exec_prepared(qry,qprms...);
+        pqxx::result r = txn.exec(qry,qprms);
         data = pqxxResultSetToJson(r);
     }  catch(const exception &e){
         cout << e.what() << endl;
@@ -136,12 +135,11 @@ json PostgreSQL::execGenericJsonQry(std::string qry, QryParams... qprms){
     return data;
 }
 
-template<typename... QryParams>
-string PostgreSQL::execGenericImgQry(string qry, QryParams...qprms){
+string PostgreSQL::execGenericImgQry(string qry, pqxx::params qprms){
     string img;
     try{
         pqxx::work txn{*c};
-        pqxx::result r = txn.exec_prepared(qry,qprms...);
+        pqxx::result r = txn.exec(qry,qprms);
         for(auto const &row: r){
             pqxx::binarystring bs = row[0].as<pqxx::binarystring>();
             img = bs.str();

--- a/src/postgresql.cpp
+++ b/src/postgresql.cpp
@@ -24,7 +24,7 @@ PostgreSQL::~PostgreSQL(){
 string PostgreSQL::toLowerCamelCase(std::string s)
 {
     transform(s.begin(), s.end(), s.begin(),
-                   [](unsigned char c){ return tolower(c); });
+              [](unsigned char c){ return tolower(c); });
 
     boost::regex re("([_-][a-z])");
     s = boost::regex_replace(s, re, [](const boost::smatch& sm){
@@ -54,16 +54,16 @@ void PostgreSQL::initializeStatements(){
                       "FROM content.vw_posts vp\n";
 
     map<string,string> queries = {
-        {"imageById","select image from content.fn_get_image_by_id($1)"},
-        {"imageByFilename", "select image from content.fn_get_image_by_filename($1)"},
-        {"postById","select * from content.fn_get_post_by_id($1)"},
-        {"recentPosts","select * from content.fn_get_recent_posts($1)"},
-        {"recentArticles","select * from content.fn_get_recent_articles($1)"},
-        {"recentProjects","select * from content.fn_get_recent_projects($1)"},
-        {"allProjects", allPosts + "WHERE vp.post_category = 'project'"},
-        {"allArticles", allPosts + "WHERE vp.post_category = 'article'"},
-        {"allPosts", allPosts},
-    };
+                                   {"imageById","select image from content.fn_get_image_by_id($1)"},
+                                   {"imageByFilename", "select image from content.fn_get_image_by_filename($1)"},
+                                   {"postById","select * from content.fn_get_post_by_id($1)"},
+                                   {"recentPosts","select * from content.fn_get_recent_posts($1)"},
+                                   {"recentArticles","select * from content.fn_get_recent_articles($1)"},
+                                   {"recentProjects","select * from content.fn_get_recent_projects($1)"},
+                                   {"allProjects", allPosts + "WHERE vp.post_category = 'project'"},
+                                   {"allArticles", allPosts + "WHERE vp.post_category = 'article'"},
+                                   {"allPosts", allPosts},
+                                   };
 
     for(auto &qry: queries){
         c->prepare(qry.first,qry.second);
@@ -122,11 +122,11 @@ nlohmann::json PostgreSQL::pqxxResultSetToJson(const pqxx::result &rs){
 }
 
 //qprms are optional for the function.
-json PostgreSQL::execGenericJsonQry(std::string qry, pqxx::params qprms = {}){
+json PostgreSQL::execGenericJsonQry(string qry, pqxx::params qprms){
     json data;
     try{
         pqxx::work txn{*c};
-        pqxx::result r = txn.exec(qry,qprms);
+        pqxx::result r = txn.exec(pqxx::prepped{qry},qprms);
         data = pqxxResultSetToJson(r);
     }  catch(const exception &e){
         cout << e.what() << endl;
@@ -139,7 +139,7 @@ string PostgreSQL::execGenericImgQry(string qry, pqxx::params qprms){
     string img;
     try{
         pqxx::work txn{*c};
-        pqxx::result r = txn.exec(qry,qprms);
+        pqxx::result r = txn.exec(pqxx::prepped{qry},qprms);
         for(auto const &row: r){
             pqxx::binarystring bs = row[0].as<pqxx::binarystring>();
             img = bs.str();

--- a/src/postgresql.cpp
+++ b/src/postgresql.cpp
@@ -105,29 +105,43 @@ nlohmann::json PostgreSQL::pqxxRowToJsonObject(const pqxx::row &r){
     return obj;
 }
 
-nlohmann::json PostgreSQL::pqxxResultSetToJson(const pqxx::result &rs){
+nlohmann::json PostgreSQL::pqxxResultSetToJson(const pqxx::result &rs, bool isArr){
     json obj;
-    if(rs.size() == 0){
-        return  obj;
-    } if(rs.size() == 1){
-        return pqxxRowToJsonObject(rs.begin());
-    } if(rs.size() > 1){
+    if(isArr){
         obj = json::array();
-        for(const auto &r:rs){
-            obj.push_back(pqxxRowToJsonObject(r));
+        if(rs.size() == 0){
+            return obj;
+        } if(rs.size() > 0){
+            for(const auto &r:rs){
+                obj.push_back(pqxxRowToJsonObject(r));
+            }
+            return obj;
         }
-        return obj;
+    } else {
+        if(rs.size() == 0){
+            return obj;
+        } if(rs.size() == 1){
+            return pqxxRowToJsonObject(rs.begin());
+        }
     }
     return obj;
 }
 
+json PostgreSQL::execGenericJsonArrQry(string qry, pqxx::params qprms){
+    return execGenericJsonQry(qry, true, qprms);
+}
+
+json PostgreSQL::execGenericJsonObjQry(string qry, pqxx::params qprms){
+    return execGenericJsonQry(qry, false, qprms);
+}
+
 //qprms are optional for the function.
-json PostgreSQL::execGenericJsonQry(string qry, pqxx::params qprms){
+json PostgreSQL::execGenericJsonQry(string qry, bool isArr, pqxx::params qprms){
     json data;
     try{
         pqxx::work txn{*c};
         pqxx::result r = txn.exec(pqxx::prepped{qry},qprms);
-        data = pqxxResultSetToJson(r);
+        data = pqxxResultSetToJson(r,isArr);
     }  catch(const exception &e){
         cout << e.what() << endl;
         throw;
@@ -160,29 +174,29 @@ string PostgreSQL::getImageByFilename(string filename){
 }
 
 json PostgreSQL::getPostById(int id){
-    return execGenericJsonQry("postById", id);
+    return execGenericJsonObjQry("postById", id);
 }
 
 json PostgreSQL::getRecentPosts(int howMany){
-    return execGenericJsonQry("recentPosts",howMany);
+    return execGenericJsonArrQry("recentPosts",howMany);
 }
 
 json PostgreSQL::getRecentArticles(int howMany){
-    return execGenericJsonQry("recentArticles",howMany);
+    return execGenericJsonArrQry("recentArticles",howMany);
 }
 
 json PostgreSQL::getRecentProjects(int howMany){
-    return execGenericJsonQry("recentProjects",howMany);
+    return execGenericJsonArrQry("recentProjects",howMany);
 }
 
 json PostgreSQL::getAllPosts(){
-    return execGenericJsonQry("allPosts");
+    return execGenericJsonArrQry("allPosts");
 }
 
 json PostgreSQL::getAllProjects(){
-    return execGenericJsonQry("allProjects");
+    return execGenericJsonArrQry("allProjects");
 }
 
 json PostgreSQL::getAllArticles(){
-    return execGenericJsonQry("allArticles");
+    return execGenericJsonArrQry("allArticles");
 }

--- a/src/postgresql.h
+++ b/src/postgresql.h
@@ -25,9 +25,9 @@ public:
     nlohmann::json getAllPosts();
     nlohmann::json getAllProjects();
 
-    nlohmann::json execGenericJsonQry(std::string qry, pqxx::params qprms = {});
-
-    std::string execGenericImgQry(std::string qry, pqxx::params qprms = {});
+    nlohmann::json execGenericJsonArrQry(std::string qry,  pqxx::params qprms = {});
+    nlohmann::json execGenericJsonObjQry(std::string qry,  pqxx::params qprms = {});
+    std::string    execGenericImgQry(std::string qry,      pqxx::params qprms);
 
 private:
     pqxx::connection *c = nullptr;
@@ -35,7 +35,8 @@ private:
     void initializeStatements();
     nlohmann::json pqxxFieldToJsonData(const pqxx::field &f);
     nlohmann::json pqxxRowToJsonObject(const pqxx::row &r);
-    nlohmann::json pqxxResultSetToJson(const pqxx::result &rs);
+    nlohmann::json pqxxResultSetToJson(const pqxx::result &rs, bool isArr);
+    nlohmann::json execGenericJsonQry(std::string qry, bool isArr, pqxx::params qprms = {});
 };
 
 #endif // POSTGRESQL_H

--- a/src/postgresql.h
+++ b/src/postgresql.h
@@ -25,9 +25,9 @@ public:
     nlohmann::json getAllPosts();
     nlohmann::json getAllProjects();
 
-    nlohmann::json execGenericJsonQry(std::string qry, pqxx::params qprms);
+    nlohmann::json execGenericJsonQry(std::string qry, pqxx::params qprms = {});
 
-    std::string execGenericImgQry(std::string qry, pqxx::params qprms);
+    std::string execGenericImgQry(std::string qry, pqxx::params qprms = {});
 
 private:
     pqxx::connection *c = nullptr;

--- a/src/postgresql.h
+++ b/src/postgresql.h
@@ -25,11 +25,9 @@ public:
     nlohmann::json getAllPosts();
     nlohmann::json getAllProjects();
 
-    template<typename... QryParams>
-    nlohmann::json execGenericJsonQry(std::string qry, QryParams... qprms);
+    nlohmann::json execGenericJsonQry(std::string qry, pqxx::params qprms);
 
-    template<typename... QryParams>
-    std::string execGenericImgQry(std::string qry, QryParams... qprms);
+    std::string execGenericImgQry(std::string qry, pqxx::params qprms);
 
 private:
     pqxx::connection *c = nullptr;


### PR DESCRIPTION
CMakeList.txt Updates:
- Boost v1.87 libraries are compiled from git.
- libpqxx v7.10.1 is compiled from git.

PostgreSQL Class Updates:
- Use pqxx::params instead of a templated parameter as recommended in libpqxx >= 7.10
- Use pqxx::prepped instead of pqxx:exec_prepped as recommended in libpqxx >= 7.10
- Added execGenericJsonObjQry wrapper function for execGenericJsonQry which returns a single json object.
- Added execGenericJsonArrQry wrapper function for execGenericJsonQry which returns a single json array object.
- execGenericJsonQry can still be used, but it now requires a isArr passed as a parameter.