### PR TITLE
DEV: Add mutex locking when the PostgreSQL class queries the database.

### DIFF
--- a/src/postgresql.cpp
+++ b/src/postgresql.cpp
@@ -126,6 +126,7 @@ json PostgreSQL::execGenericJsonObjQry(string qry, pqxx::params qprms){
 
 //qprms are optional for the function.
 json PostgreSQL::execGenericJsonQry(string qry, bool isArr, pqxx::params qprms){
+    lock_guard<mutex> lock(*cmtx);
     json data;
     try{
         pqxx::work txn{*c};
@@ -139,6 +140,7 @@ json PostgreSQL::execGenericJsonQry(string qry, bool isArr, pqxx::params qprms){
 }
 
 string PostgreSQL::execGenericImgQry(string qry, pqxx::params qprms){
+    lock_guard<mutex> lock(*cmtx);
     string img;
     try{
         pqxx::work txn{*c};

--- a/src/postgresql.h
+++ b/src/postgresql.h
@@ -5,6 +5,7 @@
 #include <pqxx/pqxx>
 #include <stdarg.h>
 #include <memory>
+#include <mutex>
 
 class PostgreSQL
 {
@@ -28,6 +29,7 @@ public:
     std::string    execGenericImgQry(std::string qry,      pqxx::params qprms);
 
 private:
+    std::shared_ptr<std::mutex> cmtx{std::make_shared<std::mutex>()};
     std::shared_ptr<pqxx::connection> c;
 
     void initializeStatements();


### PR DESCRIPTION
pqxx does not guarantee thread safety. Considering the connection pointer is shared across copies of the PostgreSQL class, mutexes are needed for thread safe operation. If operating in a multithreaded environment, each thread should inititalize its own PostgreSQL class. If copies of the same class are used the application could slow down due to mutex contention as all class copies share the same mutex and connection.